### PR TITLE
Pass glyph names to FeaParser

### DIFF
--- a/src/babelfont/convertors/glyphs.py
+++ b/src/babelfont/convertors/glyphs.py
@@ -487,7 +487,8 @@ class GlyphsTwo(BaseConvertor):
             feacode = "feature %s { %s\n} %s;" % (tag, f["code"], tag)
             featurefile = featurefile + feacode
 
-        feaparser = FeaParser(featurefile)
+        glyphNames = {g.name for g in self.font.glyphs}
+        feaparser = FeaParser(featurefile, glyphNames=glyphNames)
         ast = feaparser.parser.ast
         for name, members in self.font.features.namedClasses.items():
             glyphclass = ast.GlyphClassDefinition(

--- a/src/babelfont/convertors/gsobject.py
+++ b/src/babelfont/convertors/gsobject.py
@@ -348,7 +348,8 @@ class GSObject(BaseConvertor):
             featurefile = featurefile + feacode
 
         try:
-            feaparser = FeaParser(featurefile)
+            glyphNames = {g.name for g in self.font.glyphs}
+            feaparser = FeaParser(featurefile, glyphNames=glyphNames)
             ast = feaparser.parser.ast
             for name, members in self.font.features.namedClasses.items():
                 glyphclass = ast.GlyphClassDefinition(


### PR DESCRIPTION
Avoids the fontTools.feaLib warnings like:

   Ambiguous glyph name that looks like a range: 'seen-ar.init'