### PR TITLE
fix: Invalid escape sequence in regex string

### DIFF
--- a/src/babelfont/convertors/fontlab/vfb.py
+++ b/src/babelfont/convertors/fontlab/vfb.py
@@ -97,7 +97,7 @@ class FontlabVFB(BaseConvertor):
             if data is None:
                 continue
 
-            if name in ignore or re.match("^\d+$", name):
+            if name in ignore or re.match(r"^\d+$", name):
                 continue
             if name in store_in_scratch:
                 scratch[name].append(data)


### PR DESCRIPTION
When installing the package (at least for Python 3.12) I get the following warning:
```
/usr/lib/python3.12/site-packages/babelfont/convertors/fontlab/vfb.py:100: SyntaxWarning: invalid escape sequence '\d'
  if name in ignore or re.match("^\d+$", name):
```