### PR TITLE
Some vfbLib internals will change in v0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ read-ttf = [
     "fontfeatures >= 1.8.0",
 ]
 vfb = [
-    "vfbLib >=0.7.1",
+    "vfbLib >=0.7.1, <0.9.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Avoid installing vfbLib 0.9. Will send a separate PR with support for vfbLib 0.9.